### PR TITLE
opt-in description trimming

### DIFF
--- a/src/domains/___stub.ts.njk
+++ b/src/domains/___stub.ts.njk
@@ -10,7 +10,7 @@ class {{ ucFirst(operation_name) }}Domain {
   /**
    * Operation ID: {{ path.operationId }}
    * {% if path.summary %}Summary: {{ path.summary }}{% endif %}
-   * {% if path.description %}Description: {{ path.description }}{% endif %}
+   * {% if path.description %}Description: {{ path.description | trim }}{% endif %}
    */
   public async {{ path.operationId }} ({{ pathParamsToDomainParams(method, path, true, false, 'params') }}): Promise<{{ path['x-response-definitions']['200'] if path['x-response-definitions']['200'] else 'any' }}> {
     {% if mockServer %}

--- a/src/http/nodegen/routes/___op.ts.njk
+++ b/src/http/nodegen/routes/___op.ts.njk
@@ -19,7 +19,7 @@ export default function() {
   /**
    * Operation ID: {{ path.operationId }}
    * {% if path.summary %}Summary: {{ path.summary }}{% endif %}
-   * {% if path.description %}Description: {{ path.description }}{% endif %}
+   * {% if path.description %}Description: {{ path.description | trim }}{% endif %}
    */
       {% set securityNames = getSecurityNames(path, swagger) %}
       router.{{method}}(


### PR DESCRIPTION
closes https://github.com/acrontum/openapi-nodegen-typescript-server/issues/5

Trim descriptions in nunjuks templates for routes and domains, removing the trailing newline that appears in doxy comments.