### PR TITLE
[FEATURE] add status code parser to routes

### DIFF
--- a/src/http/nodegen/routes/___op.ts.njk
+++ b/src/http/nodegen/routes/___op.ts.njk
@@ -43,7 +43,11 @@ export default function() {
                 )
               );
             {% else %}
-              return res.json(
+              {% if getSingleSuccessResponse(path.responses) %}
+                return res.status({{ getSingleSuccessResponse(path.responses) }}).json(
+              {% else %}
+                return res.json(
+              {% endif %}
                 objectReduceByMap(
                   await {{ucFirst(operation_name)}}Domain.{{path.operationId}}({{pathParamsToDomainParams(method, path, false, true, 'params')}}),
                   {{_.camelCase(operation_name)}}TransformOutputs.{{path.operationId}}


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
By default, the http routes will always generate 200's for success. This means the swagger definitions will disagree with the implementation

**Describe the solution you'd like**
If there is a single success (200-level) response defined in the yml for a route, then it would be cool it the generated files automatically extracted that

**Describe alternatives you've considered**
Manually changing the routes, which results in being overridden on re-generate

**Additional context**
will add `.status(<code>)` if there is only 1 200-level status code in path responses

depends on https://github.com/acrontum/generate-it/pull/22