### PR TITLE
fix: remove duplicate tslib from package.json, enable 422 error middleware

### DIFF
--- a/package.json.njk
+++ b/package.json.njk
@@ -39,7 +39,6 @@
     "openapi-nodegen-logger": "^1.0.0",
     "recursive-readdir-sync": "^1.0.6",
     "request-ip": "^2.1.3",
-    "tslib": "^1.10.0",
     "winston": "^3.2.1",
     "worker-farm": "^1.7.0",
     "yamljs": "^0.3.0"

--- a/package.json.njk
+++ b/package.json.njk
@@ -39,6 +39,7 @@
     "openapi-nodegen-logger": "^1.0.0",
     "recursive-readdir-sync": "^1.0.6",
     "request-ip": "^2.1.3",
+    "tslib": "^1.11.1",
     "winston": "^3.2.1",
     "worker-farm": "^1.7.0",
     "yamljs": "^0.3.0"
@@ -66,7 +67,6 @@
     "openapi-nodegen-mockers": "^0.0.6",
     "swagger-ui-express": "^4.1.2",
     "ts-jest": "^25.4.0",
-    "tslib": "^1.11.1",
     "tslint": "^6.1.1",
     "ttypescript": "^1.5.10",
     "typescript": "^3.8.3"

--- a/src/http/middlewareErrorHandling.ts
+++ b/src/http/middlewareErrorHandling.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import handle401 from './nodegen/middleware/handle401';
 import handle403 from './nodegen/middleware/handle403';
 import handle410 from './nodegen/middleware/handle410';
+import handle422 from './nodegen/middleware/handle422';
 import handle423 from './nodegen/middleware/handle423';
 import handle429 from './nodegen/middleware/handle429';
 import handle500 from './nodegen/middleware/handle500';
@@ -19,6 +20,7 @@ export default (app: express.Application) => {
   app.use(handle401());
   app.use(handle403());
   app.use(handle410());
+  app.use(handle422());
   app.use(handle423());
   app.use(handle429());
 


### PR DESCRIPTION
Most of the 422's are handled by joi, but if we need to manually validate (eg something that cannot be expressed in the api spec) then throwing a 422 results in a 500

Current workaround:
```typescript
import http422 from '@/http/nodegen/errors/422';
...
if (some complicated condition) {
  const error = http422(`I'm sorry Dave, I'm afraid I can't do that`);
  error.joi = true;
  throw error;
}
```