### PR TITLE
[FEATURE] add json message to 422

### DIFF
--- a/src/http/nodegen/middleware/handle422.ts
+++ b/src/http/nodegen/middleware/handle422.ts
@@ -11,9 +11,9 @@ import NodegenRequest from '../../interfaces/NodegenRequest';
 export default () => {
   return (err: any, req: NodegenRequest, res: express.Response, next: express.NextFunction) => {
     if (err instanceof http422) {
-      res.status(422).send()
+      res.status(422).json({ message: err.message || 'Unprocessable' });
     } else {
-      next(err)
+      next(err);
     }
   }
 }


### PR DESCRIPTION
Allow 
```typescript
throw http422('This is an informative error')
```

There may be a better way to do this for all errors, maybe something that checks if `error.message` is defined, and if it is an object or string:
```typescript
// errors/common.ts
export const ERR_MESSAGES = {
  ...
  422: 'Unprocessable',
  500: 'Oh noes!',
}

export const respondWithError = (error: Error, res: express.Response, code: number) => {
  if (!error?.message) {
    return res.status(code).send();
  }
  if (typeof error.message === 'string') {
    return res.status(code).send(error.message || ERR_MESSAGES[code]);
  } 
  return res.status(code).json(error.message);
}
```

```typescript
// handle422.ts

    if (err instanceof http422) {
      return respondWithError(err, res, 422);
    } else {
      next(err);
    }
```