### PR TITLE
Unserialize worker thread errors to proper Error() instances.

### DIFF
--- a/src/http/nodegen/request-worker/WorkerService.ts
+++ b/src/http/nodegen/request-worker/WorkerService.ts
@@ -33,7 +33,7 @@ const REQUEST_SERIALIZED_KEYS: string[] = [
   'body',
 ];
 
-const HTTP_ERROR_CONSTRUCTORS = {
+const HTTP_ERROR_CONSTRUCTORS: { [key: string]: typeof Error } = {
   http401,
   http403,
   http404,


### PR DESCRIPTION
**Issue:**

When an error is sent from a worker thread to the main process we are getting an `http500()` with the following JSON response:
`{ message: '[object Object]' }`.

This occurs because the errors sent by the worker threads are not being properly unserialized.

**Fix:**

After this patch is applied we're now getting properly unserialized `error4*()` or `Error()` instances which are handled by their corresponding express.js middlewares.
