### PR TITLE
OA3 fixes and accomodations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The [**input**](https://github.com/acrontum/openapi-nodegen-typescript-server/bl
 
 The [**output**](https://github.com/acrontum/openapi-nodegen-typescript-server/blob/master/src/http/nodegen/routes/___op.ts.njk#L33) is protected by the npm package [object-reduce-by-map](https://www.npmjs.com/package/object-reduce-by-map) which strips out any content from an object or array, or array of objects that should not be there.
 
-Both the input and output are provided the request and response object, respectively, from the api file. 
+Both the input and output are provided the request and response object, respectively, from the api file.
 
 This means that once in the domain layer you can be safe to think that there is no additional content in the request object than that specified in the swagger file.
 
@@ -110,6 +110,18 @@ Add the nodegen generate the server to the package.json scripts object. The foll
   "scripts": {
       "generate:nodegen": "openapi-nodegen ./api_1.0.0.yml -t https://github.com/acrontum/openapi-nodegen-typescript-server.git",
 ```
+
+#### Specifying basePath in OA3
+
+If you need to specify the `basePath` edit the `src/app.ts` and add the `basePath` as second parameter to the `routesImporter`.
+
+For example:
+
+`src/app.ts`
+```typescript
+routesImporter(app, '/v1');
+```
+
 
 #### Tip 1 local api file pointer
 Typically the generation is only done during development. Typically you would orchestrate a full spec file from many little files then build 1 file to share to both openapi-nodegen and things like AWS or other gateways. To make life easier, you can simply point openapi-nodegen to the working directory of your api file repo, instead of manually copying the built file:

--- a/src/http/nodegen/routes/___op.ts.njk
+++ b/src/http/nodegen/routes/___op.ts.njk
@@ -48,7 +48,7 @@ export default function() {
               );
             {% else %}
               {% set successCode = getSingleSuccessResponse(path.responses) or 200 -%}
-              {% if path.responses[successCode].schema -%}
+              {% if path.responses[successCode].schema or (path.responses[successCode] and path.responses[successCode].content and path.responses[successCode].content["application/json"]) -%}
                 return res.status({{ successCode }}).json(
                   objectReduceByMap(
                     await {{ucFirst(operation_name)}}Domain.{{path.operationId}}({{pathParamsToDomainParams(method, path, false, true, 'params')}}),

--- a/src/http/nodegen/routesImporter.ts.njk
+++ b/src/http/nodegen/routesImporter.ts.njk
@@ -10,20 +10,20 @@ import {{prettifyRouteName(endpoint)}}Routes from './routes/{{prettifyRouteName(
 {% endif -%}
 {% endfor -%}
 
-export default function (app: express.Application) {
+export default function (app: express.Application, basePath = '') {
   {% for endpoint in endpoints -%}
     {% if(endsWith(swagger.basePath, '/')) %}
-  app.use('{{swagger.basePath}}{{endpoint}}', {{prettifyRouteName(endpoint)}}Routes())
+  app.use(basePath + '{{swagger.basePath}}{{endpoint}}', {{prettifyRouteName(endpoint)}}Routes())
     {% else %}
-  app.use('{{swagger.basePath}}/{{endpoint}}', {{prettifyRouteName(endpoint)}}Routes())
+  app.use(basePath + '{{swagger.basePath}}/{{endpoint}}', {{prettifyRouteName(endpoint)}}Routes())
     {% endif %}
   {%- endfor %}
 
   if (config.loadSwaggerUIRoute) {
     {% if(endsWith(swagger.basePath, '/')) %}
-    app.use('{{ swagger.basePath }}swagger', require('./routes/swaggerRoutes').default())
+    app.use(basePath + '{{ swagger.basePath }}swagger', require('./routes/swaggerRoutes').default())
     {% else %}
-    app.use('{{ swagger.basePath }}/swagger', require('./routes/swaggerRoutes').default())
+    app.use(basePath + '{{ swagger.basePath }}/swagger', require('./routes/swaggerRoutes').default())
     {% endif %}
   }
 }


### PR DESCRIPTION
1. Proper handling of the OA3 JSON response in the route's handler. It was previously return an empty 200 response.

2. Allow for a user to specify basePath when calling the `routesImporter`, because OA3 basePath is part of the url and it's not taken care off by the `routeImporter` template.

example:
```typescript
import express from 'express';

import middlewareErrorHandling from './http/middlewareErrorHandling';
import middlewaresImporter from './http/middlewaresImporter';
import routesImporter from './http/nodegen/routesImporter';

const app = express();

middlewaresImporter(app);
routesImporter(app, '/v1');
middlewareErrorHandling(app);

export default app;
``
Defaults to an empty string when not specified