### PR TITLE
reduce some log spam on 200 status healthcheck

### DIFF
--- a/src/http/middlewaresImporter.ts
+++ b/src/http/middlewaresImporter.ts
@@ -46,6 +46,9 @@ const accessLogger = (app: express.Application): void => {
   app.use(
     morgan(
       `[${packageJson.name}] :remote-addr [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length]`,
+      {
+        skip: (req: express.Reqest, res: express.Response) => /\/admin\/health$/.test(req.originalUrl) && res.statusCode === 200
+      }
     ),
   );
 };


### PR DESCRIPTION
When tailing the logs from services which do healthchecks, some errors can get swallowed up by the constant logging.

Not sure if this should be in the template, done manually, or just use `grep -v` in the logs, but this seemed to be an easy way to remove it by default.

This assumes healthchecks occur at `.*/admin/health`