### PR TITLE
Add the nested domains as a default option

### DIFF
--- a/.nodegenrc
+++ b/.nodegenrc
@@ -2,6 +2,8 @@
   "nodegenDir": "src/http/nodegen",
   "nodegenMockDir": "src/domains/__mocks__",
   "nodegenType": "server",
+  "segmentFirstGrouping": 2,
+  "segmentSecondGrouping": 4,
   "helpers": {
     "stub": {
       "jwtType": "JwtAccess",


### PR DESCRIPTION
Add nesting as a default option - it is much easier to turn this off than to later turn it on... i keep forgetting about this feature until i realise i need it